### PR TITLE
Race in cache fix

### DIFF
--- a/2-race-in-cache/README.md
+++ b/2-race-in-cache/README.md
@@ -9,15 +9,15 @@ are fine, but multiple writers are not.
 
 # Test your solution
 
-Use the following command to test for race conditions:
+Use the following command to test for race conditions and correct functionality:
 ```
-go run -race *.go
+go test -race
 ```
 
 Correct solution:
 No output = solution correct:
 ```
-$ go run -race *.go
+$ go test -race
 $
 ```
 

--- a/2-race-in-cache/check_test.go
+++ b/2-race-in-cache/check_test.go
@@ -1,0 +1,22 @@
+//////////////////////////////////////////////////////////////////////
+//
+// DO NOT EDIT THIS PART
+// Your task is to edit `main.go`
+//
+
+package main
+
+import "testing"
+
+func TestMain(t *testing.T) {
+	cache := run()
+
+	cacheLen := len(cache.cache)
+	pagesLen := cache.pages.Len()
+	if cacheLen != CacheSize {
+		t.Errorf("Incorrect cache size %v", cacheLen)
+	}
+	if pagesLen != CacheSize {
+		t.Errorf("Incorrect pages size %v", pagesLen)
+	}
+}

--- a/2-race-in-cache/main.go
+++ b/2-race-in-cache/main.go
@@ -41,6 +41,7 @@ func (k *KeyStoreCache) Get(key string) string {
 	// Miss - load from database and save it in cache
 	if !ok {
 		val = k.load(key)
+		k.cache[key] = val
 		k.pages.PushFront(key)
 
 		// if cache is full remove the least used item

--- a/2-race-in-cache/main.go
+++ b/2-race-in-cache/main.go
@@ -69,11 +69,17 @@ func (l *Loader) Load(key string) string {
 	return val
 }
 
-func main() {
+func run() *KeyStoreCache {
 	loader := Loader{
 		DB: GetMockDB(),
 	}
 	cache := New(&loader)
 
 	RunMockServer(cache)
+
+	return cache
+}
+
+func main() {
+	run()
 }


### PR DESCRIPTION
I noticed that exercise 2 "race-in-cache" doesn't actually write values into the KeyStoreCache.cache map, which means the cache size limiting doesn't work and also eliminates some of the race conditions that should be present.

Was this intentional for some reason? Figured I'd submit the trivial PR in case it's not.

Also added a test case for this exercise that will fail if the race conditions are removed but the cache map or pages list aren't updated correctly.